### PR TITLE
ci: add Nix workflow to github actions

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,30 @@
+name: Nix Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-13
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Run Nix Build
+        run: nix build --print-build-logs .


### PR DESCRIPTION
Since the project has Nix files, adding a CI workflow which checks it builds with Nix is straightforward.