### PR TITLE
Update ghc965

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
 { pkgs ? import <nixpkgs> {}
-, ghcVersion ? "92"
+, ghcVersion ? "965"
 }:
 pkgs.haskell.packages.${"ghc" + ghcVersion}.callPackage ./my-hakyll-blog.nix {}

--- a/example.com-shell.nix
+++ b/example.com-shell.nix
@@ -1,6 +1,6 @@
 {
   nixpkgs ? import <nixpkgs> {},
-  compiler ? "ghc92",
+  compiler ? "ghc965",
 }:
 nixpkgs.mkShell {
   buildInputs = with nixpkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = (import nixpkgs {inherit system;}).pkgs;
       # c.f. pkgs/top-level/haskell-packages.nix
-      ghcVersion = "92";
+      ghcVersion = "965";
     in rec {
       packages = {
         my-hakyll-blog = self.packages.${system}.default;

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {}
 , my-hakyll-blog ? import ./default.nix {}
-, ghcVersion ? "92"
+, ghcVersion ? "965"
 }:
 
 pkgs.mkShell {

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -1,6 +1,6 @@
 {
   nixpkgs ? import <nixpkgs> {},
-  compiler ? "ghc92",
+  compiler ? "ghc965",
 }:
 nixpkgs.mkShell {
   buildInputs = with nixpkgs;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For advanced use and comprehensive documentation of the format, please see:
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: lts-20.26
+resolver: lts-22.23
 
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2
-    size: 650475
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/26.yaml
-  original: lts-20.26
+    sha256: 73ad581de7c5306278aec7706cafaf3b1c2eb7abf4ab586e4d9dc675c6106c4e
+    size: 718708
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/23.yaml
+  original: lts-22.23


### PR DESCRIPTION
Ultimately, want `skylighting` `v0.14.1.2`. Stackage lts 22.23 has this version. This stackage uses a newer GHC, so the Nix code gets updated to use this, too.